### PR TITLE
Fix coverage

### DIFF
--- a/buildSrc/src/main/groovy/myproject.jacoco-aggregation.gradle
+++ b/buildSrc/src/main/groovy/myproject.jacoco-aggregation.gradle
@@ -7,6 +7,17 @@ repositories {
     jcenter()
 }
 
+def sourcesOutputPath = configurations.create("sourcesOutputPath") {
+    visible = false
+    canBeResolved = true
+    canBeConsumed = false
+    extendsFrom(configurations.implementation)
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'source-output-folders'))
+    }
+}
 // A resolvable configuration to collect source code
 def sourcesPath = configurations.create("sourcesPath") {
     visible = false
@@ -35,7 +46,7 @@ def coverageDataPath = configurations.create("coverageDataPath") {
 
 // Task to gather code coverage from multiple subprojects
 def codeCoverageReport = tasks.register('codeCoverageReport', JacocoReport) {
-    additionalClassDirs(configurations.runtimeClasspath)
+    additionalClassDirs(sourcesOutputPath.incoming.artifactView { lenient(true) }.files)
     additionalSourceDirs(sourcesPath.incoming.artifactView { lenient(true) }.files)
     executionData(coverageDataPath.incoming.artifactView { lenient(true) }.files.filter { it.exists() })
 

--- a/buildSrc/src/main/groovy/myproject.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/myproject.java-conventions.gradle
@@ -25,6 +25,19 @@ tasks.named("jacocoTestReport") {
 }
 
 // Share sources folder with other projects for aggregated JaCoCo reports
+configurations.create('transitiveSourceOutputsElements') {
+    visible = false
+    canBeResolved = false
+    canBeConsumed = true
+    extendsFrom(configurations.implementation)
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+        attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'source-output-folders'))
+    }
+    outgoing.artifact(sourceSets.main.java.outputDir)
+}
+// Share sources folder with other projects for aggregated JaCoCo reports
 configurations.create('transitiveSourcesElements') {
     visible = false
     canBeResolved = false


### PR DESCRIPTION
The underlying issue was that additionalClassDirs received all the compilation classpath. Including code not written in that project but grabbed by dependencies.
I reused the same pattern to obtain all output directories for main source sets without third parties.